### PR TITLE
Retrieve recipe names from title element

### DIFF
--- a/recipe_scrapers/donnahay.py
+++ b/recipe_scrapers/donnahay.py
@@ -38,7 +38,7 @@ class DonnaHay(AbstractScraper):
         return "Donna Hay"
 
     def title(self):
-        return self.soup.find("h1", class_="recipe-title__mobile").text
+        return self.soup.find("title").text.split("|")[0].strip()
 
     def yields(self):
         div = self.soup.find("div", class_="col-sm-6 method")

--- a/tests/test_data/donnahay.com.au/donnahay_1.json
+++ b/tests/test_data/donnahay.com.au/donnahay_1.json
@@ -4,7 +4,7 @@
   "site_name": "Donna Hay",
   "author": "Donna Hay",
   "language": "en",
-  "title": "green minestrone soup",
+  "title": "Green Minestrone Soup",
   "ingredients": [
     "1 tablespoon extra virgin olive oil",
     "1 leek, trimmed and sliced",

--- a/tests/test_data/donnahay.com.au/donnahay_2.json
+++ b/tests/test_data/donnahay.com.au/donnahay_2.json
@@ -4,7 +4,7 @@
   "site_name": "Donna Hay",
   "author": "Donna Hay",
   "language": "en",
-  "title": "baba ghanoush",
+  "title": "Smoky Eggplant Dip With Hand Cut Potato Chips",
   "ingredients": [
     "2 large eggplants (aubergines)",
     "1 clove garlic, crushed",


### PR DESCRIPTION
This PR changes the scraper to draw recipe names from the title element rather than the main header element. This allows for better names for some recipes, since the header element does not always contain the entire recipe name.